### PR TITLE
added 5 to move enum

### DIFF
--- a/slippi/event.py
+++ b/slippi/event.py
@@ -272,6 +272,7 @@ class Attack(IntEnum):
     JAB = 2
     JAB_2 = 3
     JAB_3 = 4
+    ERR_Fix = 5
     DASH_ATTACK = 6
     FTILT = 7
     UTILT = 8


### PR DESCRIPTION
Fixes a ValueError by adding 5 to the class(Attack) enum.

Error: `ValueError: 5 is not a valid Attack`

Fix: Added  `    ERR_Fix = 5`